### PR TITLE
Fix TypeError crash when attachment payload is None (closes #28)

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -184,11 +184,14 @@ def get_attachments(filename : str, investigation):
     # Get Attachments from Mail
     attachments = []
     for attachment in msg.iter_attachments():
+        payload = attachment.get_payload(decode=True)
+        if payload is None:
+            continue
         attached_file = {}
         attached_file["filename"] = attachment.get_filename()
-        attached_file["MD5"] = hashlib.md5(attachment.get_payload(decode=True)).hexdigest()
-        attached_file["SHA1"] = hashlib.sha1(attachment.get_payload(decode=True)).hexdigest()
-        attached_file["SHA256"] = hashlib.sha256(attachment.get_payload(decode=True)).hexdigest()
+        attached_file["MD5"]    = hashlib.md5(payload).hexdigest()
+        attached_file["SHA1"]   = hashlib.sha1(payload).hexdigest()
+        attached_file["SHA256"] = hashlib.sha256(payload).hexdigest()
         attachments.append(attached_file)
 
     for index,attachment in enumerate(attachments,start=1):

--- a/tests/fixtures/multipart_alternative.eml
+++ b/tests/fixtures/multipart_alternative.eml
@@ -1,0 +1,33 @@
+Content-Type: multipart/mixed; boundary="===============9180908962875686407=="
+MIME-Version: 1.0
+From: sender@example.com
+To: victim@example.com
+Subject: Multipart Alternative Sub-Part
+
+--===============9180908962875686407==
+Content-Type: multipart/alternative; boundary="===============7371444051602121717=="
+MIME-Version: 1.0
+
+--===============7371444051602121717==
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+Plain text body.
+--===============7371444051602121717==
+Content-Type: text/html; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+<p>HTML body.</p>
+--===============7371444051602121717==--
+
+--===============9180908962875686407==
+Content-Type: application/octet-stream
+MIME-Version: 1.0
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="real.pdf"
+
+JVBERi0xLjQ=
+
+--===============9180908962875686407==--

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -238,6 +238,37 @@ class TestInvestigationMode:
         assert result["Attachments"]["Investigation"] == {}
 
 
+class TestRegressionBug28:
+    """Regression tests for Bug #28 — TypeError when get_payload(decode=True) returns None."""
+
+    def test_none_payload_does_not_crash(self):
+        """multipart/alternative sub-parts return None payload — must not raise TypeError."""
+        result = get_attachments(fixture_path("multipart_alternative.eml"), investigation=False)
+        assert result is not None
+
+    def test_none_payload_part_is_skipped(self):
+        """The undecodable sub-part must be skipped; the real attachment must still appear."""
+        result = get_attachments(fixture_path("multipart_alternative.eml"), investigation=False)
+        data = result["Attachments"]["Data"]
+
+        assert len(data) == 1
+        assert data["1"] == "real.pdf"
+
+    def test_none_payload_real_attachment_hashes_computed(self):
+        """After skipping None payload, the real attachment must still be hashed correctly."""
+        result = get_attachments(fixture_path("multipart_alternative.eml"), investigation=True)
+        inv = result["Attachments"]["Investigation"]["real.pdf"]["Virustotal"]
+
+        assert len(inv["MD5"].split("/")[-1])    == 32
+        assert len(inv["SHA1"].split("/")[-1])   == 40
+        assert len(inv["SHA256"].split("/")[-1]) == 64
+
+    def test_email_with_only_none_payload_returns_empty(self):
+        """An email where all attachment parts have None payload must return empty data."""
+        result = get_attachments(fixture_path("no_attachment.eml"), investigation=False)
+        assert result["Attachments"]["Data"] == {}
+
+
 class TestRegressionBug27:
     """Regression tests for Bug #27 — UnicodeDecodeError on binary attachments."""
 


### PR DESCRIPTION
get_payload(decode=True) returns None for multipart sub-parts. Decode payload once, skip attachment with continue if None instead of passing None to hashlib. Also eliminates 3 redundant decode calls.