### PR TITLE
Fix None attachment filename used as dict key causing TypeError (clos…

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -183,12 +183,12 @@ def get_attachments(filename : str, investigation):
 
     # Get Attachments from Mail
     attachments = []
-    for attachment in msg.iter_attachments():
+    for index, attachment in enumerate(msg.iter_attachments(), start=1):
         payload = attachment.get_payload(decode=True)
         if payload is None:
             continue
         attached_file = {}
-        attached_file["filename"] = attachment.get_filename()
+        attached_file["filename"] = attachment.get_filename() or f"unnamed_attachment_{index}"
         attached_file["MD5"]    = hashlib.md5(payload).hexdigest()
         attached_file["SHA1"]   = hashlib.sha1(payload).hexdigest()
         attached_file["SHA256"] = hashlib.sha256(payload).hexdigest()

--- a/tests/fixtures/no_filename_attachment.eml
+++ b/tests/fixtures/no_filename_attachment.eml
@@ -1,0 +1,21 @@
+Content-Type: multipart/mixed; boundary="===============3924290447773545141=="
+MIME-Version: 1.0
+From: sender@example.com
+To: victim@example.com
+Subject: No Filename Attachment
+
+--===============3924290447773545141==
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+See attached.
+--===============3924290447773545141==
+Content-Type: application/octet-stream
+MIME-Version: 1.0
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment
+
+QUJDREVGR0g=
+
+--===============3924290447773545141==--

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -238,6 +238,53 @@ class TestInvestigationMode:
         assert result["Attachments"]["Investigation"] == {}
 
 
+class TestRegressionBug29:
+    """Regression tests for Bug #29 — None filename used as dict key causing TypeError."""
+
+    def test_none_filename_does_not_crash(self):
+        """Previously: None stored as filename, then used as dict key → TypeError."""
+        result = get_attachments(fixture_path("no_filename_attachment.eml"), investigation=False)
+        assert result is not None
+
+    def test_none_filename_replaced_with_fallback(self):
+        """Attachment with no Content-Disposition filename must get a fallback name."""
+        result = get_attachments(fixture_path("no_filename_attachment.eml"), investigation=False)
+        data = result["Attachments"]["Data"]
+
+        assert len(data) == 1
+        assert data["1"] is not None
+        assert "unnamed_attachment" in data["1"]
+
+    def test_none_filename_fallback_is_string(self):
+        """Fallback filename must be a non-empty string."""
+        result = get_attachments(fixture_path("no_filename_attachment.eml"), investigation=False)
+        filename = result["Attachments"]["Data"]["1"]
+
+        assert isinstance(filename, str)
+        assert len(filename) > 0
+
+    def test_none_filename_investigation_uses_fallback_as_key(self):
+        """Investigation dict must use the fallback name as key, not None."""
+        result = get_attachments(fixture_path("no_filename_attachment.eml"), investigation=True)
+        inv = result["Attachments"]["Investigation"]
+
+        assert None not in inv
+        assert len(inv) == 1
+        key = list(inv.keys())[0]
+        assert "unnamed_attachment" in key
+
+    def test_none_filename_hashes_still_computed(self):
+        """Even with a fallback filename, hashes must be computed correctly."""
+        result = get_attachments(fixture_path("no_filename_attachment.eml"), investigation=True)
+        inv = result["Attachments"]["Investigation"]
+        key = list(inv.keys())[0]
+        vt = inv[key]["Virustotal"]
+
+        assert len(vt["MD5"].split("/")[-1])    == 32
+        assert len(vt["SHA1"].split("/")[-1])   == 40
+        assert len(vt["SHA256"].split("/")[-1]) == 64
+
+
 class TestRegressionBug28:
     """Regression tests for Bug #28 — TypeError when get_payload(decode=True) returns None."""
 


### PR DESCRIPTION
…es #29)

get_filename() returns None when Content-Disposition has no filename parameter. Fall back to "unnamed_attachment_{index}" using or-expression so the value is always a usable string key. Moved enumerate to outer loop to make the index available for the fallback name.