### PR TITLE
Fix #31: read file once as binary, pass bytes to get_digests()

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -94,13 +94,11 @@ def get_headers(mail_data : str, investigation):
 
     return data
 
-def get_digests(mail_data : str, filename : str, investigation):
+def get_digests(mail_data : str, file_bytes : bytes, investigation):
     '''Get Hash value of mail'''
-    with open(filename, 'rb') as f:
-        eml_file    = f.read()
-        file_md5    = hashlib.md5(eml_file).hexdigest()
-        file_sha1   = hashlib.sha1(eml_file).hexdigest()
-        file_sha256 = hashlib.sha256(eml_file).hexdigest()
+    file_md5    = hashlib.md5(file_bytes).hexdigest()
+    file_sha1   = hashlib.sha1(file_bytes).hexdigest()
+    file_sha256 = hashlib.sha256(file_bytes).hexdigest()
 
     content_md5     = hashlib.md5(mail_data.encode("utf-8")).hexdigest()
     content_sha1    = hashlib.sha1(mail_data.encode("utf-8")).hexdigest()
@@ -400,8 +398,9 @@ if __name__ == '__main__':
             print(f"{file_format} file format not supported")
             sys.exit(-1) #Exit with error code
     
-    with open(filename,"r",encoding="utf-8",errors="replace") as file:
-        data = file.read().rstrip()
+    with open(filename,"rb") as file:
+        file_bytes = file.read()
+    data = file_bytes.decode("utf-8", errors="replace").rstrip()
 
     # Create JSON data
     app_data = json.loads('{"Information": {}, "Analysis":{}}')
@@ -429,7 +428,7 @@ if __name__ == '__main__':
         # Digests
         if args.digests:
             # Get Digests
-            digests = get_digests(data, filename, args.investigate)
+            digests = get_digests(data, file_bytes, args.investigate)
             app_data["Analysis"].update(digests)
 
         # Links
@@ -462,7 +461,7 @@ if __name__ == '__main__':
         app_data["Analysis"].update(headers)
 
         # Get Digests
-        digests = get_digests(data, filename, investigate)
+        digests = get_digests(data, file_bytes, investigate)
         app_data["Analysis"].update(digests)
 
         # Get & Print Links

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,11 @@ def load_fixture(name: str) -> str:
     return (FIXTURES_DIR / name).read_text(encoding="utf-8")
 
 
+def load_fixture_bytes(name: str) -> bytes:
+    """Read a fixture .eml file and return its raw bytes (mirrors the fixed main block)."""
+    return (FIXTURES_DIR / name).read_bytes()
+
+
 def fixture_path(name: str) -> str:
     """Return the absolute path string of a fixture file."""
     return str(FIXTURES_DIR / name)

--- a/tests/test_digests.py
+++ b/tests/test_digests.py
@@ -13,18 +13,19 @@ Covers:
 - Investigation links contain the actual hash value
 - Investigation disabled returns empty investigation
 - Same file produces same hashes (deterministic)
+- Regression #31: file read once as binary, no double-open inconsistency
 """
 
 import pytest
 import hashlib
-from conftest import get_digests, load_fixture, fixture_path
+from conftest import get_digests, load_fixture, load_fixture_bytes, fixture_path
 
 
 class TestDigestExtraction:
     def test_all_six_hashes_present(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
         data = result["Digests"]["Data"]
 
         assert "File MD5"       in data
@@ -35,36 +36,36 @@ class TestDigestExtraction:
         assert "Content SHA256" in data
 
     def test_md5_is_32_hex_chars(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
         data = result["Digests"]["Data"]
 
         assert len(data["File MD5"]) == 32
         assert len(data["Content MD5"]) == 32
 
     def test_sha1_is_40_hex_chars(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
         data = result["Digests"]["Data"]
 
         assert len(data["File SHA1"]) == 40
         assert len(data["Content SHA1"]) == 40
 
     def test_sha256_is_64_hex_chars(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
         data = result["Digests"]["Data"]
 
         assert len(data["File SHA256"]) == 64
         assert len(data["Content SHA256"]) == 64
 
     def test_all_hashes_are_lowercase_hex(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
         data = result["Digests"]["Data"]
 
         valid_chars = set("0123456789abcdef")
@@ -73,65 +74,70 @@ class TestDigestExtraction:
 
     def test_file_sha256_matches_direct_hash(self):
         """File hash must match independently computed hash of the raw file bytes."""
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
 
-        with open(path, "rb") as f:
-            expected = hashlib.sha256(f.read()).hexdigest()
-
+        expected = hashlib.sha256(file_bytes).hexdigest()
         assert result["Digests"]["Data"]["File SHA256"] == expected
 
     def test_file_md5_matches_direct_hash(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
 
-        with open(path, "rb") as f:
-            expected = hashlib.md5(f.read()).hexdigest()
-
+        expected = hashlib.md5(file_bytes).hexdigest()
         assert result["Digests"]["Data"]["File MD5"] == expected
+
+    def test_file_sha1_matches_direct_hash(self):
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
+
+        expected = hashlib.sha1(file_bytes).hexdigest()
+        assert result["Digests"]["Data"]["File SHA1"] == expected
 
     def test_content_sha256_matches_direct_hash(self):
         """Content hash must match hashlib computed from mail_data string."""
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
 
         expected = hashlib.sha256(mail_data.encode("utf-8")).hexdigest()
         assert result["Digests"]["Data"]["Content SHA256"] == expected
 
     def test_content_md5_matches_direct_hash(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
 
         expected = hashlib.md5(mail_data.encode("utf-8")).hexdigest()
         assert result["Digests"]["Data"]["Content MD5"] == expected
 
-    def test_file_sha1_matches_direct_hash(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
-
-        with open(path, "rb") as f:
-            expected = hashlib.sha1(f.read()).hexdigest()
-
-        assert result["Digests"]["Data"]["File SHA1"] == expected
-
     def test_content_sha1_matches_direct_hash(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
 
         expected = hashlib.sha1(mail_data.encode("utf-8")).hexdigest()
         assert result["Digests"]["Data"]["Content SHA1"] == expected
 
+    def test_file_hash_and_content_hash_are_independent_computations(self):
+        """File hash: raw bytes. Content hash: mail_data re-encoded to UTF-8.
+        Both must be independently verifiable."""
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
+        data = result["Digests"]["Data"]
+
+        assert data["File SHA256"]    == hashlib.sha256(file_bytes).hexdigest()
+        assert data["Content SHA256"] == hashlib.sha256(mail_data.encode("utf-8")).hexdigest()
+
     def test_all_six_hashes_present_on_different_fixture(self):
         """Six hashes must be produced for any valid .eml, not just basic.eml."""
-        path = fixture_path("spoofed.eml")
-        mail_data = load_fixture("spoofed.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("spoofed.eml")
+        mail_data  = load_fixture("spoofed.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
         data = result["Digests"]["Data"]
 
         for key in ["File MD5", "File SHA1", "File SHA256",
@@ -140,56 +146,37 @@ class TestDigestExtraction:
 
     def test_hashes_correct_on_different_fixture(self):
         """File SHA256 must match direct computation for a second fixture."""
-        path = fixture_path("spoofed.eml")
-        mail_data = load_fixture("spoofed.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("spoofed.eml")
+        mail_data  = load_fixture("spoofed.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
 
-        with open(path, "rb") as f:
-            expected = hashlib.sha256(f.read()).hexdigest()
-
-        assert result["Digests"]["Data"]["File SHA256"] == expected
-
-    def test_file_hash_and_content_hash_are_independent_computations(self):
-        """File and content hashes are computed via different code paths.
-        File hash: raw binary read of the .eml file.
-        Content hash: the mail_data string re-encoded to UTF-8.
-        Both must be valid 64-char hex strings independently verifiable."""
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
-        data = result["Digests"]["Data"]
-
-        # Verify each independently rather than asserting they differ —
-        # on pure-ASCII files with LF endings both paths produce the same bytes.
-        with open(path, "rb") as f:
-            assert data["File SHA256"] == hashlib.sha256(f.read()).hexdigest()
-        assert data["Content SHA256"] == hashlib.sha256(mail_data.encode("utf-8")).hexdigest()
+        assert result["Digests"]["Data"]["File SHA256"] == hashlib.sha256(file_bytes).hexdigest()
 
     def test_different_files_produce_different_hashes(self):
         """Two distinct .eml files must produce different hash values."""
-        path1 = fixture_path("basic.eml")
-        path2 = fixture_path("spoofed.eml")
-        mail1 = load_fixture("basic.eml")
-        mail2 = load_fixture("spoofed.eml")
+        bytes1 = load_fixture_bytes("basic.eml")
+        bytes2 = load_fixture_bytes("spoofed.eml")
+        mail1  = load_fixture("basic.eml")
+        mail2  = load_fixture("spoofed.eml")
 
-        result1 = get_digests(mail1, path1, investigation=False)
-        result2 = get_digests(mail2, path2, investigation=False)
+        result1 = get_digests(mail1, bytes1, investigation=False)
+        result2 = get_digests(mail2, bytes2, investigation=False)
 
         assert result1["Digests"]["Data"]["File SHA256"] != result2["Digests"]["Data"]["File SHA256"]
         assert result1["Digests"]["Data"]["Content SHA256"] != result2["Digests"]["Data"]["Content SHA256"]
 
     def test_hashes_are_deterministic(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result1 = get_digests(mail_data, path, investigation=False)
-        result2 = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result1 = get_digests(mail_data, file_bytes, investigation=False)
+        result2 = get_digests(mail_data, file_bytes, investigation=False)
 
         assert result1["Digests"]["Data"] == result2["Digests"]["Data"]
 
     def test_returns_correct_structure(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
 
         assert "Digests" in result
         assert "Data" in result["Digests"]
@@ -198,15 +185,15 @@ class TestDigestExtraction:
 
 class TestInvestigationMode:
     def test_investigation_disabled_returns_empty(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
         assert result["Digests"]["Investigation"] == {}
 
     def test_investigation_generates_virustotal_links_for_all_hashes(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=True)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=True)
         inv = result["Digests"]["Investigation"]
 
         for key in ["File MD5", "File SHA1", "File SHA256",
@@ -216,9 +203,9 @@ class TestInvestigationMode:
             assert "virustotal.com" in inv[key]["Virustotal"]
 
     def test_investigation_links_contain_actual_hash_value(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=True)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=True)
 
         for key in ["File MD5", "File SHA1", "File SHA256",
                     "Content MD5", "Content SHA1", "Content SHA256"]:
@@ -227,7 +214,42 @@ class TestInvestigationMode:
             assert hash_val in vt_link, f"{key} hash value not found in VT link"
 
     def test_investigation_count_matches_data_count(self):
-        path = fixture_path("basic.eml")
-        mail_data = load_fixture("basic.eml")
-        result = get_digests(mail_data, path, investigation=True)
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=True)
         assert len(result["Digests"]["Data"]) == len(result["Digests"]["Investigation"])
+
+
+class TestRegressionBug31:
+    """Regression tests for Bug #31 — file opened twice with inconsistent modes."""
+
+    def test_file_opened_once_file_hash_matches_raw_bytes(self):
+        """File hash must match bytes read directly — no double-open, no mode mismatch."""
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+        result = get_digests(mail_data, file_bytes, investigation=False)
+
+        # Verify against the exact bytes passed in — not a re-read of the file
+        assert result["Digests"]["Data"]["File SHA256"] == hashlib.sha256(file_bytes).hexdigest()
+        assert result["Digests"]["Data"]["File MD5"]    == hashlib.md5(file_bytes).hexdigest()
+
+    def test_no_filename_parameter_in_get_digests(self):
+        """get_digests must accept bytes, not a filename string."""
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = load_fixture("basic.eml")
+
+        # Passing bytes must work; passing a string path must raise TypeError
+        result = get_digests(mail_data, file_bytes, investigation=False)
+        assert result is not None
+
+        with pytest.raises((TypeError, AttributeError)):
+            get_digests(mail_data, fixture_path("basic.eml"), investigation=False)
+
+    def test_content_hash_consistent_with_decoded_string(self):
+        """Content hash is from mail_data (decoded string), not raw bytes."""
+        file_bytes = load_fixture_bytes("basic.eml")
+        mail_data  = file_bytes.decode("utf-8", errors="replace").rstrip()
+        result = get_digests(mail_data, file_bytes, investigation=False)
+
+        expected = hashlib.sha256(mail_data.encode("utf-8")).hexdigest()
+        assert result["Digests"]["Data"]["Content SHA256"] == expected

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -15,7 +15,7 @@ import pytest
 from pathlib import Path
 from conftest import (
     get_headers, get_links, get_digests,
-    load_fixture, fixture_path, FIXTURES_DIR
+    load_fixture, load_fixture_bytes, fixture_path, FIXTURES_DIR
 )
 
 
@@ -78,9 +78,9 @@ class TestRegressionBug30:
 
     def test_latin1_email_digests_computable(self):
         """get_digests() must still compute hashes on a Latin-1 email."""
-        path = fixture_path("latin1_encoded.eml")
+        file_bytes = load_fixture_bytes("latin1_encoded.eml")
         mail_data = load_fixture_replace("latin1_encoded.eml")
-        result = get_digests(mail_data, path, investigation=False)
+        result = get_digests(mail_data, file_bytes, investigation=False)
 
         assert len(result["Digests"]["Data"]["File SHA256"]) == 64
         assert len(result["Digests"]["Data"]["Content SHA256"]) == 64


### PR DESCRIPTION
Previously get_digests() reopened the file in binary mode internally while the main block used text mode, causing CRLF-related hash inconsistencies on Windows. Now the main block reads the file once as binary, decodes to string for analysis, and passes raw bytes to get_digests() directly.

- get_digests signature: (mail_data, filename) -> (mail_data, file_bytes)
- Main block: open(rb) + decode() instead of open(r, encoding=utf-8)
- Updated both get_digests call sites to pass file_bytes
- Updated test_digests.py to use load_fixture_bytes() helper
- Added TestRegressionBug31 (3 tests) to test_digests.py
- Fixed test_encoding.py to use load_fixture_bytes() instead of path string