### PR TITLE
Fix #33: assign unique IDs to each navbar dropdown

### DIFF
--- a/html_generator.py
+++ b/html_generator.py
@@ -272,37 +272,37 @@ def generate_table_from_json(json_obj):
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav mr-auto">
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="nav-link dropdown-toggle" href="#" id="headersDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Headers
                     </a>
-                    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                    <div class="dropdown-menu" aria-labelledby="headersDropdown">
                     <a class="dropdown-item" href="#headers-data-section">Data <span class="badge badge-pill badge-dark">{ headers_cnt }</span></a>
                     <a class="dropdown-item" href="#headers-investigation-section">Investigation <span class="badge badge-pill badge-dark">{ headers_inv_cnt }</span></a>
                     </div>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="nav-link dropdown-toggle" href="#" id="linksDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Links
                     </a>
-                    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                    <div class="dropdown-menu" aria-labelledby="linksDropdown">
                     <a class="dropdown-item" href="#links-data-section">Data <span class="badge badge-pill badge-dark">{ links_cnt }</span></a>
                     <a class="dropdown-item" href="#links-investigation-section">Investigation <span class="badge badge-pill badge-dark">{ links_inv_cnt }</span></a>
                     </div>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="nav-link dropdown-toggle" href="#" id="attachmentsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Attachments
                     </a>
-                    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                    <div class="dropdown-menu" aria-labelledby="attachmentsDropdown">
                     <a class="dropdown-item" href="#attachments-data-section">Data <span class="badge badge-pill badge-dark">{ attach_cnt }</span></a>
                     <a class="dropdown-item" href="#attachments-investigation-section">Investigation <span class="badge badge-pill badge-dark">{ attach_inv_cnt }</span></a>
                     </div>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <a class="nav-link dropdown-toggle" href="#" id="digestsDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Digests
                     </a>
-                    <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                    <div class="dropdown-menu" aria-labelledby="digestsDropdown">
                     <a class="dropdown-item" href="#digests-data-section">Data <span class="badge badge-pill badge-dark">{ digest_cnt }</span></a>
                     <a class="dropdown-item" href="#digests-investigation-section">Investigation <span class="badge badge-pill badge-dark">{ digest_inv_cnt }</span></a>
                     </div>

--- a/tests/test_html_generator.py
+++ b/tests/test_html_generator.py
@@ -334,3 +334,73 @@ class TestRegressionBug32:
         html = generate_headers_section(data)
         assert "user@example.com" in html
         assert "&amp;" not in html or "user" in html  # no spurious encoding
+
+
+# ---------------------------------------------------------------------------
+# Regression #33 — duplicate navbarDropdown IDs
+# ---------------------------------------------------------------------------
+
+class TestRegressionBug33:
+    """Regression tests for Bug #33 — four dropdowns sharing id='navbarDropdown'."""
+
+    def test_navbardropdown_id_not_duplicated(self):
+        """The generic id='navbarDropdown' must not appear in the generated HTML."""
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'id="navbarDropdown"' not in html
+
+    def test_headers_dropdown_has_unique_id(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'id="headersDropdown"' in html
+
+    def test_links_dropdown_has_unique_id(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'id="linksDropdown"' in html
+
+    def test_attachments_dropdown_has_unique_id(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'id="attachmentsDropdown"' in html
+
+    def test_digests_dropdown_has_unique_id(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'id="digestsDropdown"' in html
+
+    def test_all_four_dropdown_ids_are_distinct(self):
+        """Each dropdown must have a unique ID — no two dropdowns share the same id."""
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        ids = ["headersDropdown", "linksDropdown", "attachmentsDropdown", "digestsDropdown"]
+        assert len(ids) == len(set(ids))  # sanity
+        for id_ in ids:
+            assert html.count(f'id="{id_}"') == 1, f'{id_} appears more than once'
+
+    def test_aria_labelledby_matches_id_for_headers(self):
+        """aria-labelledby must reference the same unique ID as the toggle button."""
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'aria-labelledby="headersDropdown"' in html
+
+    def test_aria_labelledby_matches_id_for_links(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'aria-labelledby="linksDropdown"' in html
+
+    def test_aria_labelledby_matches_id_for_attachments(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'aria-labelledby="attachmentsDropdown"' in html
+
+    def test_aria_labelledby_matches_id_for_digests(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'aria-labelledby="digestsDropdown"' in html
+
+    def test_aria_labelledby_navbardropdown_not_present(self):
+        """The old mismatched aria-labelledby='navbarDropdown' must be gone."""
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'aria-labelledby="navbarDropdown"' not in html


### PR DESCRIPTION
All four Bootstrap navbar dropdowns shared id="navbarDropdown", which is invalid HTML and caused Bootstrap JS to bind only to the first matching element, leaving Links, Attachments, and Digests dropdowns non-functional in some browsers.

- Headers: id="headersDropdown" / aria-labelledby="headersDropdown"
- Links:   id="linksDropdown"   / aria-labelledby="linksDropdown"
- Attachments: id="attachmentsDropdown" / aria-labelledby="attachmentsDropdown"
- Digests: id="digestsDropdown" / aria-labelledby="digestsDropdown"
- Added TestRegressionBug33 (11 tests) to test_html_generator.py