### PR TITLE
feat #47: extract and investigate public IPs from Received headers

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -12,6 +12,7 @@ import re
 import quopri
 import os
 import json
+import ipaddress
 from datetime import datetime
 from banners import (
     get_introduction_banner,get_headers_banner,get_links_banner,
@@ -31,6 +32,7 @@ SUPPORTED_OUTPUT_TYPES = ["json","html"]
 # REGEX
 LINK_REGEX = r'href=\"((?:\S)*)\"'
 MAIL_REGEX = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b'
+IP_REGEX   = r'\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b'
 
 # Date Format
 DATE_FORMAT = "%B %d, %Y - %H:%M:%S"
@@ -41,6 +43,14 @@ TER_COL_SIZE = 60
 
 # Functions
 ##############################################################################
+def _is_public_ip(ip_str):
+    '''Return True if the IP is a valid, globally routable address'''
+    try:
+        ip = ipaddress.ip_address(ip_str)
+        return ip.is_global and not ip.is_multicast
+    except ValueError:
+        return False
+
 def get_headers(mail_data : str, investigation):
     '''Get Headers from mail data'''
     # Get Headers from mail data
@@ -66,6 +76,21 @@ def get_headers(mail_data : str, investigation):
                 "Abuseipdb":f'https://www.abuseipdb.com/check/{data["Headers"]["Data"]["x-sender-ip"]}'
             }
         
+        # Received Header IP Investigation
+        if data["Headers"]["Data"].get("received"):
+            received_ips = dict.fromkeys(
+                ip for ip in re.findall(IP_REGEX, data["Headers"]["Data"]["received"])
+                if _is_public_ip(ip)
+            )
+            if received_ips:
+                data["Headers"]["Investigation"]["Received IPs"] = {
+                    ip: {
+                        "Virustotal": f"https://www.virustotal.com/gui/search/{ip}",
+                        "Abuseipdb":  f"https://www.abuseipdb.com/check/{ip}"
+                    }
+                    for ip in received_ips
+                }
+
         # Reply To - From Investigation (Spoof Check)
         if data["Headers"]["Data"].get("reply-to") and data["Headers"]["Data"].get("from"):
             # Get Reply-To Address

--- a/tests/fixtures/received_mixed_ips.eml
+++ b/tests/fixtures/received_mixed_ips.eml
@@ -1,0 +1,11 @@
+Received: from mail.attacker.com (8.8.4.4) by internal.corp.com with SMTP; Wed, 08 Apr 2026 09:00:00 +0000
+Received: from internal.corp.com (10.0.0.5) by mail.corp.com with SMTP; Wed, 08 Apr 2026 08:58:00 +0000
+Received: from localhost (127.0.0.1) by internal.corp.com with SMTP; Wed, 08 Apr 2026 08:56:00 +0000
+From: sender@example.com
+To: recipient@example.com
+Subject: Mixed IPs Received Test
+Date: Wed, 08 Apr 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain
+
+Email with both public and private IPs in Received headers.

--- a/tests/fixtures/received_public_ips.eml
+++ b/tests/fixtures/received_public_ips.eml
@@ -1,0 +1,10 @@
+Received: from mail.attacker.com (8.8.8.8) by mail.victim.com with SMTP; Wed, 08 Apr 2026 09:00:00 +0000
+Received: from relay.provider.com (1.1.1.1) by mail.attacker.com with SMTP; Wed, 08 Apr 2026 08:55:00 +0000
+From: sender@example.com
+To: recipient@example.com
+Subject: Public IP Received Test
+Date: Wed, 08 Apr 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain
+
+Email body with public IPs in Received headers.

--- a/tests/test_received_ips.py
+++ b/tests/test_received_ips.py
@@ -1,0 +1,183 @@
+"""
+Tests for Received header IP extraction (Enhancement #47)
+
+Covers:
+- Public IPs from Received headers appear in investigation
+- Each IP has VirusTotal and AbuseIPDB links
+- Private IPs (RFC 1918) are excluded from investigation
+- Loopback (127.0.0.1) is excluded from investigation
+- Duplicate IPs across multiple Received headers deduplicated
+- No Received header produces no Received IPs investigation entry
+- Investigation disabled returns no Received IPs entry
+- VT and AbuseIPDB URLs contain the actual IP value
+- VT URL uses correct format (virustotal.com/gui/search/)
+- AbuseIPDB URL uses correct format (abuseipdb.com/check/)
+- Mixed public/private: only public IPs appear
+- Multiple distinct public IPs all appear
+"""
+
+import pytest
+from conftest import get_headers, load_fixture
+
+
+class TestPublicIPExtraction:
+    def test_public_ips_present_in_investigation(self):
+        """Public IPs from Received headers must appear in investigation."""
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        assert "Received IPs" in result["Headers"]["Investigation"]
+
+    def test_both_public_ips_extracted(self):
+        """All distinct public IPs must be present as keys."""
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+
+        assert "8.8.8.8" in ips
+        assert "1.1.1.1" in ips
+
+    def test_each_ip_has_virustotal_link(self):
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+
+        for ip, links in ips.items():
+            assert "Virustotal" in links, f"No Virustotal link for {ip}"
+
+    def test_each_ip_has_abuseipdb_link(self):
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+
+        for ip, links in ips.items():
+            assert "Abuseipdb" in links, f"No Abuseipdb link for {ip}"
+
+    def test_virustotal_url_contains_ip(self):
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+
+        for ip, links in ips.items():
+            assert ip in links["Virustotal"], f"IP {ip} not in VT URL"
+
+    def test_abuseipdb_url_contains_ip(self):
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+
+        for ip, links in ips.items():
+            assert ip in links["Abuseipdb"], f"IP {ip} not in AbuseIPDB URL"
+
+    def test_virustotal_url_exact_format(self):
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+        ip = "8.8.8.8"
+
+        assert ips[ip]["Virustotal"] == f"https://www.virustotal.com/gui/search/{ip}"
+
+    def test_abuseipdb_url_exact_format(self):
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+        ip = "8.8.8.8"
+
+        assert ips[ip]["Abuseipdb"] == f"https://www.abuseipdb.com/check/{ip}"
+
+
+class TestPrivateIPFiltering:
+    def test_private_rfc1918_ips_excluded(self):
+        """10.x.x.x and 192.168.x.x addresses must not appear in investigation."""
+        mail_data = load_fixture("received_mixed_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+
+        assert "10.0.0.5" not in ips
+        assert "192.168.1.1" not in ips
+
+    def test_loopback_excluded(self):
+        """127.0.0.1 must not appear in investigation."""
+        mail_data = load_fixture("received_mixed_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+
+        assert "127.0.0.1" not in ips
+
+    def test_only_public_ip_extracted_from_mixed(self):
+        """Only the public IP must appear when Received headers contain mixed IPs."""
+        mail_data = load_fixture("received_mixed_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+
+        assert "8.8.4.4" in ips
+        assert len(ips) == 1
+
+    def test_all_private_ips_produces_no_received_ips_entry(self):
+        """When all Received IPs are private, Received IPs must not appear in investigation."""
+        mail_data = load_fixture("multi_received.eml")
+        result = get_headers(mail_data, investigation=True)
+
+        assert "Received IPs" not in result["Headers"]["Investigation"]
+
+
+class TestDeduplication:
+    def test_duplicate_ips_deduplicated(self):
+        """The same public IP appearing in multiple Received headers must appear only once."""
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        ips = result["Headers"]["Investigation"]["Received IPs"]
+
+        ip_list = list(ips.keys())
+        assert len(ip_list) == len(set(ip_list))
+
+
+class TestInvestigationDisabled:
+    def test_investigation_disabled_no_received_ips(self):
+        """With investigation=False, Received IPs must not appear."""
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=False)
+
+        assert "Received IPs" not in result["Headers"]["Investigation"]
+
+    def test_investigation_disabled_returns_empty_investigation(self):
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=False)
+
+        assert result["Headers"]["Investigation"] == {}
+
+
+class TestNoReceivedHeader:
+    def test_no_received_header_no_crash(self):
+        """Emails without Received headers must not crash."""
+        mail_data = load_fixture("minimal.eml")
+        result = get_headers(mail_data, investigation=True)
+        assert result is not None
+
+    def test_no_received_header_no_received_ips_entry(self):
+        mail_data = load_fixture("minimal.eml")
+        result = get_headers(mail_data, investigation=True)
+        assert "Received IPs" not in result["Headers"]["Investigation"]
+
+
+class TestRegressionEnhancement47:
+    """Regression tests for Enhancement #47 — Received IPs not investigated."""
+
+    def test_public_ip_was_previously_ignored(self):
+        """Previously public IPs in Received were not linked to any investigation tool."""
+        mail_data = load_fixture("received_public_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        inv = result["Headers"]["Investigation"]
+
+        assert "Received IPs" in inv
+        assert len(inv["Received IPs"]) > 0
+
+    def test_private_ip_still_not_investigated(self):
+        """Private IPs must never appear in investigation regardless of context."""
+        mail_data = load_fixture("received_mixed_ips.eml")
+        result = get_headers(mail_data, investigation=True)
+        inv = result["Headers"]["Investigation"].get("Received IPs", {})
+
+        for ip in inv:
+            assert not ip.startswith("10.")
+            assert not ip.startswith("192.168.")
+            assert not ip.startswith("127.")


### PR DESCRIPTION
All Received headers are now parsed for IP addresses during investigation. Public (globally routable) IPs are linked to VirusTotal and AbuseIPDB, matching the existing X-Sender-Ip investigation format. Private IPs (RFC 1918, loopback, reserved ranges) are excluded as they have no investigative value. Duplicate IPs across multiple Received hops are deduplicated.

- Add import ipaddress to email-analyzer.py
- Add IP_REGEX constant for IPv4 extraction
- Add _is_public_ip() helper using ipaddress.ip_address.is_global
- Add Received IPs investigation block in get_headers()
- Added fixtures: received_public_ips.eml, received_mixed_ips.eml
- Added tests/test_received_ips.py with 19 tests