### PR TITLE
feat #49: add MIME type to attachment data output

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -239,14 +239,18 @@ def get_attachments(filename : str, investigation):
         if payload is None:
             continue
         attached_file = {}
-        attached_file["filename"] = attachment.get_filename() or f"unnamed_attachment_{index}"
+        attached_file["filename"]  = attachment.get_filename() or f"unnamed_attachment_{index}"
+        attached_file["mime_type"] = attachment.get_content_type()
         attached_file["MD5"]    = hashlib.md5(payload).hexdigest()
         attached_file["SHA1"]   = hashlib.sha1(payload).hexdigest()
         attached_file["SHA256"] = hashlib.sha256(payload).hexdigest()
         attachments.append(attached_file)
 
     for index,attachment in enumerate(attachments,start=1):
-        data["Attachments"]["Data"][str(index)] = attachment["filename"]
+        data["Attachments"]["Data"][str(index)] = {
+            "filename":  attachment["filename"],
+            "mime_type": attachment["mime_type"]
+        }
 
     # If investigation requested
     if investigation:
@@ -350,7 +354,7 @@ def print_data(data):
 
         # Print Attachments
         for key,val in data["Analysis"]["Attachments"]["Data"].items():
-            print(f"[{key}]->{val}")
+            print(f"[{key}] {val['filename']} ({val['mime_type']})")
             print("_"*TER_COL_SIZE)
         
         # Print Investigation

--- a/html_generator.py
+++ b/html_generator.py
@@ -118,8 +118,9 @@ def generate_attachment_section(attachments):
         <table class="table table-bordered table-striped">
             <thead>
                 <tr>
-                    <th>Key</th>
-                    <th>Value</th>
+                    <th>#</th>
+                    <th>Filename</th>
+                    <th>MIME Type</th>
                 </tr>
             </thead>
         <tbody>
@@ -127,7 +128,11 @@ def generate_attachment_section(attachments):
     for key,value in attachments["Data"].items():
         # Populate table rows
         html += "<tr>"
-        html += "<td>{}</td><td>{}</td>".format(escape(str(key)), escape(str(value)))
+        html += "<td>{}</td><td>{}</td><td>{}</td>".format(
+            escape(str(key)),
+            escape(str(value["filename"])),
+            escape(str(value["mime_type"]))
+        )
         html += "</tr>"
         
     html += """

--- a/tests/test_attachment_mime.py
+++ b/tests/test_attachment_mime.py
@@ -1,0 +1,113 @@
+"""
+Tests for attachment MIME type in output (Enhancement #49)
+
+Covers:
+- Data values are dicts with 'filename' and 'mime_type' keys
+- application/octet-stream MIME type captured for binary attachment
+- image/png MIME type captured for image attachment
+- MIME type is a non-empty string
+- MIME type follows type/subtype format
+- Multiple attachments each have their own mime_type
+- Filename still correct alongside mime_type
+- No attachments returns empty Data
+- mime_type present regardless of investigation flag
+- Regression #49: MIME type was previously absent from output
+"""
+
+import pytest
+from conftest import get_attachments, fixture_path
+
+
+class TestDataStructure:
+    def test_data_value_is_dict(self):
+        """Data entry must be a dict, not a plain string."""
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        data = result["Attachments"]["Data"]
+        assert isinstance(data["1"], dict)
+
+    def test_data_value_has_filename_key(self):
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        assert "filename" in result["Attachments"]["Data"]["1"]
+
+    def test_data_value_has_mime_type_key(self):
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        assert "mime_type" in result["Attachments"]["Data"]["1"]
+
+    def test_filename_value_correct(self):
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        assert result["Attachments"]["Data"]["1"]["filename"] == "malware.pdf"
+
+    def test_no_attachments_still_empty(self):
+        result = get_attachments(fixture_path("no_attachment.eml"), investigation=False)
+        assert result["Attachments"]["Data"] == {}
+
+
+class TestMimeTypeValues:
+    def test_binary_attachment_mime_type(self):
+        """application/octet-stream must be captured for binary attachment."""
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        assert result["Attachments"]["Data"]["1"]["mime_type"] == "application/octet-stream"
+
+    def test_image_attachment_mime_type(self):
+        """image/png must be captured for PNG image attachment."""
+        result = get_attachments(fixture_path("image_attachment.eml"), investigation=False)
+        assert result["Attachments"]["Data"]["1"]["mime_type"] == "image/png"
+
+    def test_mime_type_is_non_empty_string(self):
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        mime = result["Attachments"]["Data"]["1"]["mime_type"]
+        assert isinstance(mime, str)
+        assert len(mime) > 0
+
+    def test_mime_type_contains_slash(self):
+        """MIME type must follow the type/subtype format."""
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        mime = result["Attachments"]["Data"]["1"]["mime_type"]
+        assert "/" in mime
+
+    def test_multiple_attachments_each_have_mime_type(self):
+        result = get_attachments(fixture_path("multi_attachment.eml"), investigation=False)
+        data = result["Attachments"]["Data"]
+        for idx, val in data.items():
+            assert "mime_type" in val, f"Attachment {idx} missing mime_type"
+            assert len(val["mime_type"]) > 0
+
+    def test_mime_type_present_with_investigation_disabled(self):
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        assert "mime_type" in result["Attachments"]["Data"]["1"]
+
+    def test_mime_type_present_with_investigation_enabled(self):
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=True)
+        assert "mime_type" in result["Attachments"]["Data"]["1"]
+
+    def test_image_filename_and_mime_type_together(self):
+        """filename and mime_type must both be correct for image attachment."""
+        result = get_attachments(fixture_path("image_attachment.eml"), investigation=False)
+        entry = result["Attachments"]["Data"]["1"]
+        assert entry["filename"] == "logo.png"
+        assert entry["mime_type"] == "image/png"
+
+
+class TestRegressionEnhancement49:
+    """Regression tests for Enhancement #49 — MIME type absent from attachment output."""
+
+    def test_mime_type_was_previously_absent(self):
+        """Previously Data['1'] was a plain string (filename only). Now it must be a dict."""
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        entry = result["Attachments"]["Data"]["1"]
+        assert not isinstance(entry, str), "Data value must be a dict, not a plain string"
+
+    def test_mime_type_accessible_without_string_parsing(self):
+        """Caller must not need to parse raw headers to get the MIME type."""
+        result = get_attachments(fixture_path("image_attachment.eml"), investigation=False)
+        mime = result["Attachments"]["Data"]["1"]["mime_type"]
+        assert mime == "image/png"
+
+    def test_disguised_file_mime_type_detectable(self):
+        """A file with a .pdf extension but binary MIME type must expose the true type."""
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=False)
+        entry = result["Attachments"]["Data"]["1"]
+        # malware.pdf has application/octet-stream, not application/pdf
+        assert entry["filename"] == "malware.pdf"
+        assert entry["mime_type"] == "application/octet-stream"
+        assert entry["mime_type"] != "application/pdf"

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -44,11 +44,11 @@ class TestAttachmentExtraction:
         data = result["Attachments"]["Data"]
 
         assert len(data) == 1
-        assert data["1"] == "malware.pdf"
+        assert data["1"]["filename"] == "malware.pdf"
 
     def test_text_attachment_detected(self):
         result = get_attachments(fixture_path("multi_attachment.eml"), investigation=False)
-        names = list(result["Attachments"]["Data"].values())
+        names = [v["filename"] for v in result["Attachments"]["Data"].values()]
         assert "config.txt" in names
 
     def test_multiple_attachments_all_detected(self):
@@ -56,7 +56,7 @@ class TestAttachmentExtraction:
         data = result["Attachments"]["Data"]
 
         assert len(data) == 3
-        names = list(data.values())
+        names = [v["filename"] for v in data.values()]
         assert "document.pdf" in names
         assert "config.txt"   in names
         assert "payload.exe"  in names
@@ -67,7 +67,7 @@ class TestAttachmentExtraction:
         data = result["Attachments"]["Data"]
 
         assert len(data) == 1
-        assert data["1"] == "logo.png"
+        assert data["1"]["filename"] == "logo.png"
 
     def test_no_attachments_returns_empty(self):
         result = get_attachments(fixture_path("no_attachment.eml"), investigation=False)
@@ -252,13 +252,13 @@ class TestRegressionBug29:
         data = result["Attachments"]["Data"]
 
         assert len(data) == 1
-        assert data["1"] is not None
-        assert "unnamed_attachment" in data["1"]
+        assert data["1"]["filename"] is not None
+        assert "unnamed_attachment" in data["1"]["filename"]
 
     def test_none_filename_fallback_is_string(self):
         """Fallback filename must be a non-empty string."""
         result = get_attachments(fixture_path("no_filename_attachment.eml"), investigation=False)
-        filename = result["Attachments"]["Data"]["1"]
+        filename = result["Attachments"]["Data"]["1"]["filename"]
 
         assert isinstance(filename, str)
         assert len(filename) > 0
@@ -299,7 +299,7 @@ class TestRegressionBug28:
         data = result["Attachments"]["Data"]
 
         assert len(data) == 1
-        assert data["1"] == "real.pdf"
+        assert data["1"]["filename"] == "real.pdf"
 
     def test_none_payload_real_attachment_hashes_computed(self):
         """After skipping None payload, the real attachment must still be hashed correctly."""

--- a/tests/test_html_generator.py
+++ b/tests/test_html_generator.py
@@ -156,16 +156,20 @@ class TestLinksSectionEscaping:
 # Attachments section
 # ---------------------------------------------------------------------------
 
+def make_attachment_entry(filename, mime_type="application/octet-stream"):
+    return {"filename": filename, "mime_type": mime_type}
+
+
 class TestAttachmentsSectionEscaping:
     def test_attachment_filename_xss_escaped_in_data(self):
-        data = {"Data": {"1": xss_payload()}, "Investigation": {}}
+        data = {"Data": {"1": make_attachment_entry(xss_payload())}, "Investigation": {}}
         html = generate_attachment_section(data)
         assert "<script>" not in html
         assert "&lt;script&gt;" in html
 
     def test_attachment_index_xss_escaped_in_investigation(self):
         data = {
-            "Data": {"1": "malware.pdf"},
+            "Data": {"1": make_attachment_entry("malware.pdf")},
             "Investigation": {
                 xss_payload(): {"Virustotal": {"SHA256": "https://virustotal.com/test"}}
             }
@@ -175,7 +179,7 @@ class TestAttachmentsSectionEscaping:
 
     def test_attachment_url_xss_escaped_in_investigation_href(self):
         data = {
-            "Data": {"1": "malware.pdf"},
+            "Data": {"1": make_attachment_entry("malware.pdf")},
             "Investigation": {
                 "malware.pdf": {
                     "Virustotal": {"SHA256": f"https://virustotal.com/{xss_payload()}"}
@@ -187,7 +191,7 @@ class TestAttachmentsSectionEscaping:
 
     def test_attachment_hash_type_escaped_in_investigation(self):
         data = {
-            "Data": {"1": "malware.pdf"},
+            "Data": {"1": make_attachment_entry("malware.pdf")},
             "Investigation": {
                 "malware.pdf": {
                     "Virustotal": {xss_payload(): "https://virustotal.com/test"}
@@ -198,15 +202,25 @@ class TestAttachmentsSectionEscaping:
         assert "<script>" not in html
 
     def test_safe_attachment_filename_rendered_correctly(self):
-        data = {"Data": {"1": "document.pdf"}, "Investigation": {}}
+        data = {"Data": {"1": make_attachment_entry("document.pdf")}, "Investigation": {}}
         html = generate_attachment_section(data)
         assert "document.pdf" in html
 
     def test_attachment_filename_with_special_chars_escaped(self):
-        data = {"Data": {"1": "file<name>.pdf"}, "Investigation": {}}
+        data = {"Data": {"1": make_attachment_entry("file<name>.pdf")}, "Investigation": {}}
         html = generate_attachment_section(data)
         assert "<name>" not in html
         assert "&lt;name&gt;" in html
+
+    def test_attachment_mime_type_rendered(self):
+        data = {"Data": {"1": make_attachment_entry("invoice.pdf", "application/x-msdownload")}, "Investigation": {}}
+        html = generate_attachment_section(data)
+        assert "application/x-msdownload" in html
+
+    def test_attachment_mime_type_xss_escaped(self):
+        data = {"Data": {"1": make_attachment_entry("file.pdf", xss_payload())}, "Investigation": {}}
+        html = generate_attachment_section(data)
+        assert "<script>" not in html
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +311,7 @@ class TestRegressionBug32:
 
     def test_xss_payload_in_attachment_filename_cannot_execute_script(self):
         data = {
-            "Data": {"1": '"><script>alert(1)</script>'},
+            "Data": {"1": make_attachment_entry('"><script>alert(1)</script>')},
             "Investigation": {}
         }
         html = generate_attachment_section(data)


### PR DESCRIPTION
get_attachments() now captures attachment.get_content_type() for each attachment and stores it alongside the filename. Data values change from plain strings to dicts with 'filename' and 'mime_type' keys, enabling detection of disguised files (e.g. a .pdf with MIME type application/x-msdownload).

- Capture mime_type via attachment.get_content_type() in get_attachments()
- Data values changed: {"1": "file.pdf"} -> {"1": {"filename": "file.pdf", "mime_type": "..."}}
- Update print_data() to display filename and mime_type together
- Update generate_attachment_section() in html_generator.py with 3-column table
- Updated test_attachments.py to use new dict structure
- Updated test_html_generator.py to use new dict structure + 2 new MIME tests
- Added tests/test_attachment_mime.py with 14 tests