### PR TITLE
Add duplicate attachment detection (#51)

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -279,6 +279,14 @@ def get_attachments(filename : str, investigation):
                 }
             }
 
+        # Detect duplicate attachments by SHA256
+        sha256_map = {}
+        for attachment in attachments:
+            sha256_map.setdefault(attachment["SHA256"], []).append(attachment["filename"])
+        duplicates = {sha: names for sha, names in sha256_map.items() if len(names) > 1}
+        if duplicates:
+            data["Attachments"]["Investigation"]["Duplicate Warning"] = duplicates
+
     return data
 ##############################################################################
 

--- a/html_generator.py
+++ b/html_generator.py
@@ -157,9 +157,14 @@ def generate_attachment_section(attachments):
         # Populate table rows
         html += "<tr>"
         html += "<td>{}</td><td>".format(escape(str(index)))
-        for k,v in values.items():
-            for x,y in v.items():
-                html += f"<b><a href='{escape(y)}' target='_blank'>{escape(x)} Scan({escape(k)})</a></b><br>"
+        if index == "Duplicate Warning":
+            for sha,names in values.items():
+                joined = ", ".join(escape(n) for n in names)
+                html += f"<b>{escape(sha)}</b>: {joined}<br>"
+        else:
+            for k,v in values.items():
+                for x,y in v.items():
+                    html += f"<b><a href='{escape(y)}' target='_blank'>{escape(x)} Scan({escape(k)})</a></b><br>"
         html += "</td></tr>"
         
     html += """

--- a/tests/fixtures/duplicate_attachments.eml
+++ b/tests/fixtures/duplicate_attachments.eml
@@ -1,0 +1,34 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Duplicate Attachment Test
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="boundary_dup"
+
+--boundary_dup
+Content-Type: text/plain
+
+Test email with duplicate attachments.
+
+--boundary_dup
+Content-Type: application/octet-stream
+Content-Disposition: attachment; filename="invoice.pdf"
+Content-Transfer-Encoding: base64
+
+VGhpcyBpcyBkdXBsaWNhdGUgY29udGVudCBmb3IgdGVzdGluZy4=
+
+--boundary_dup
+Content-Type: application/octet-stream
+Content-Disposition: attachment; filename="receipt.pdf"
+Content-Transfer-Encoding: base64
+
+VGhpcyBpcyBkdXBsaWNhdGUgY29udGVudCBmb3IgdGVzdGluZy4=
+
+--boundary_dup
+Content-Type: text/plain
+Content-Disposition: attachment; filename="readme.txt"
+Content-Transfer-Encoding: base64
+
+VGhpcyBpcyB1bmlxdWUgY29udGVudC4=
+
+--boundary_dup--
+

--- a/tests/test_duplicate_attachments.py
+++ b/tests/test_duplicate_attachments.py
@@ -1,0 +1,128 @@
+"""
+Tests for duplicate attachment detection (Enhancement #51)
+
+Covers:
+- Duplicate Warning key present when duplicates exist
+- Duplicate Warning key absent when no duplicates
+- Duplicate Warning key absent when investigation=False
+- Duplicate Warning maps SHA256 to list of filenames
+- List contains all filenames sharing the hash
+- Unique attachment not included in Duplicate Warning
+- SHA256 key in Duplicate Warning is a valid 64-char hex string
+- Two identical attachments produce one SHA256 entry with two filenames
+- Regular investigation entries still present alongside Duplicate Warning
+- Regression #51: duplicate attachments previously silently undetected
+"""
+
+import pytest
+import hashlib
+from conftest import get_attachments, fixture_path
+
+
+class TestDuplicateDetection:
+    def test_duplicate_warning_present_when_duplicates_exist(self):
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=True)
+        assert "Duplicate Warning" in result["Attachments"]["Investigation"]
+
+    def test_duplicate_warning_absent_when_no_duplicates(self):
+        result = get_attachments(fixture_path("multi_attachment.eml"), investigation=True)
+        assert "Duplicate Warning" not in result["Attachments"]["Investigation"]
+
+    def test_duplicate_warning_absent_when_investigation_false(self):
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=False)
+        assert "Duplicate Warning" not in result["Attachments"]["Investigation"]
+
+    def test_duplicate_warning_maps_sha256_to_filenames(self):
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=True)
+        warning = result["Attachments"]["Investigation"]["Duplicate Warning"]
+        assert isinstance(warning, dict)
+        # Each key is a SHA256, each value is a list
+        for sha, names in warning.items():
+            assert isinstance(sha, str)
+            assert isinstance(names, list)
+
+    def test_duplicate_warning_sha256_is_64_hex_chars(self):
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=True)
+        warning = result["Attachments"]["Investigation"]["Duplicate Warning"]
+        for sha in warning.keys():
+            assert len(sha) == 64
+            assert all(c in "0123456789abcdef" for c in sha)
+
+    def test_duplicate_warning_contains_both_duplicate_filenames(self):
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=True)
+        warning = result["Attachments"]["Investigation"]["Duplicate Warning"]
+        all_names = [name for names in warning.values() for name in names]
+        assert "invoice.pdf" in all_names
+        assert "receipt.pdf" in all_names
+
+    def test_unique_attachment_not_in_duplicate_warning(self):
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=True)
+        warning = result["Attachments"]["Investigation"]["Duplicate Warning"]
+        all_names = [name for names in warning.values() for name in names]
+        assert "readme.txt" not in all_names
+
+    def test_two_duplicates_produce_one_sha256_entry(self):
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=True)
+        warning = result["Attachments"]["Investigation"]["Duplicate Warning"]
+        assert len(warning) == 1
+
+    def test_duplicate_sha256_entry_has_two_filenames(self):
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=True)
+        warning = result["Attachments"]["Investigation"]["Duplicate Warning"]
+        sha, names = next(iter(warning.items()))
+        assert len(names) == 2
+
+    def test_duplicate_sha256_matches_actual_content_hash(self):
+        """SHA256 key in Duplicate Warning must match the real hash of the duplicate content."""
+        import email as email_mod
+        import email.policy
+        path = fixture_path("duplicate_attachments.eml")
+        with open(path, "rb") as f:
+            msg = email_mod.message_from_binary_file(f, policy=email_mod.policy.default)
+        payloads = {}
+        for part in msg.iter_attachments():
+            fname = part.get_filename()
+            payload = part.get_payload(decode=True)
+            if payload is not None and fname in ("invoice.pdf", "receipt.pdf"):
+                payloads[fname] = payload
+
+        expected_sha = hashlib.sha256(payloads["invoice.pdf"]).hexdigest()
+        assert payloads["invoice.pdf"] == payloads["receipt.pdf"]
+
+        result = get_attachments(path, investigation=True)
+        warning = result["Attachments"]["Investigation"]["Duplicate Warning"]
+        assert expected_sha in warning
+
+    def test_regular_investigation_entries_still_present(self):
+        """VT links for individual attachments must still appear alongside Duplicate Warning."""
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=True)
+        inv = result["Attachments"]["Investigation"]
+        assert "invoice.pdf" in inv
+        assert "receipt.pdf" in inv
+        assert "readme.txt" in inv
+
+    def test_no_attachments_no_duplicate_warning(self):
+        result = get_attachments(fixture_path("no_attachment.eml"), investigation=True)
+        assert "Duplicate Warning" not in result["Attachments"]["Investigation"]
+
+    def test_single_attachment_no_duplicate_warning(self):
+        result = get_attachments(fixture_path("binary_attachment.eml"), investigation=True)
+        assert "Duplicate Warning" not in result["Attachments"]["Investigation"]
+
+
+class TestRegressionEnhancement51:
+    """Regression tests for Enhancement #51 — duplicate attachments silently undetected."""
+
+    def test_duplicate_content_detected_across_different_filenames(self):
+        """invoice.pdf and receipt.pdf have identical content — must be flagged."""
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=True)
+        warning = result["Attachments"]["Investigation"]["Duplicate Warning"]
+        all_names = [name for names in warning.values() for name in names]
+        assert "invoice.pdf" in all_names
+        assert "receipt.pdf" in all_names
+
+    def test_duplicate_warning_only_when_investigation_requested(self):
+        """Duplicate Warning must not appear in Data section or without investigation flag."""
+        result = get_attachments(fixture_path("duplicate_attachments.eml"), investigation=False)
+        assert "Duplicate Warning" not in result["Attachments"]["Data"]
+        assert "Duplicate Warning" not in result["Attachments"]["Investigation"]


### PR DESCRIPTION
After computing hashes for all attachments, SHA256 values are compared across attachments. When duplicates are found and investigation is enabled, a "Duplicate Warning" entry is added to the Investigation section mapping each shared SHA256 to the list of filenames that share it. html_generator updated to render the warning correctly.