### PR TITLE
Fix LINK_REGEX to match single-quoted href attributes (#60)

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -30,7 +30,7 @@ SUPPORTED_FILE_TYPES = ["eml"]
 SUPPORTED_OUTPUT_TYPES = ["json","html"]
 
 # REGEX
-LINK_REGEX = r'href=\"((?:\S)*)\"'
+LINK_REGEX = r'href=["\']([^"\'>\s]+)["\']'
 MAIL_REGEX = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b'
 IP_REGEX   = r'\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b'
 AUTH_REGEX = r'\b(spf|dkim|dmarc)=(pass|fail|softfail|neutral|none|temperror|permerror)\b'

--- a/tests/fixtures/single_quote_links.eml
+++ b/tests/fixtures/single_quote_links.eml
@@ -1,0 +1,15 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Single Quote Href Test
+Date: Wed, 02 Apr 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/html; charset="utf-8"
+
+<!DOCTYPE html>
+<html>
+<body>
+<p><a href='https://single-quote-site.com/page'>Click here</a></p>
+<p><a href='https://another-single.com/path'>Another link</a></p>
+<p><a href="https://double-quote-site.com/page">Double quoted</a></p>
+</body>
+</html>

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -239,6 +239,45 @@ class TestRegressionBug25:
             assert "Urlscan" in entry
 
 
+class TestRegressionBug60:
+    """Regression tests for Bug #60 — single-quoted href links silently missed."""
+
+    def test_single_quoted_href_extracted(self):
+        """Links inside single-quoted href attributes must be found."""
+        mail_data = load_fixture("single_quote_links.eml")
+        result = get_links(mail_data, investigation=False)
+        data = result["Links"]["Data"]
+
+        assert any("single-quote-site.com" in v for v in data.values())
+
+    def test_double_quoted_href_still_extracted(self):
+        """Double-quoted href links must still be found after the regex change."""
+        mail_data = load_fixture("single_quote_links.eml")
+        result = get_links(mail_data, investigation=False)
+        data = result["Links"]["Data"]
+
+        assert any("double-quote-site.com" in v for v in data.values())
+
+    def test_mixed_quote_styles_all_extracted(self):
+        """Email with both single and double quoted hrefs must extract all links."""
+        mail_data = load_fixture("single_quote_links.eml")
+        result = get_links(mail_data, investigation=False)
+        data = result["Links"]["Data"]
+
+        assert len(data) == 3
+
+    def test_single_quoted_link_in_investigation(self):
+        """Single-quoted href links must also appear in investigation output."""
+        mail_data = load_fixture("single_quote_links.eml")
+        result = get_links(mail_data, investigation=True)
+        inv = result["Links"]["Investigation"]
+
+        assert len(inv) == 3
+        for entry in inv.values():
+            assert "Virustotal" in entry
+            assert "Urlscan" in entry
+
+
 class TestRegressionBug59:
     """Regression tests for Bug #59 — QP decoding applied to entire raw email."""
 


### PR DESCRIPTION
The previous regex only matched href="..." (double quotes), silently dropping any link using href='...' (single quotes). Updated regex to match both quote styles while stopping at >, whitespace, or the closing quote to prevent runaway matches.