### PR TITLE
Fix unnamed attachment fallback index mismatch (#62)

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -260,12 +260,14 @@ def get_attachments(filename : str, investigation):
 
     # Get Attachments from Mail
     attachments = []
-    for index, attachment in enumerate(msg.iter_attachments(), start=1):
+    collected = 0
+    for attachment in msg.iter_attachments():
         payload = attachment.get_payload(decode=True)
         if payload is None:
             continue
+        collected += 1
         attached_file = {}
-        attached_file["filename"]  = attachment.get_filename() or f"unnamed_attachment_{index}"
+        attached_file["filename"]  = attachment.get_filename() or f"unnamed_attachment_{collected}"
         attached_file["mime_type"] = attachment.get_content_type()
         attached_file["MD5"]    = hashlib.md5(payload).hexdigest()
         attached_file["SHA1"]   = hashlib.sha1(payload).hexdigest()

--- a/tests/fixtures/skipped_then_unnamed_attachment.eml
+++ b/tests/fixtures/skipped_then_unnamed_attachment.eml
@@ -1,0 +1,22 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Skipped Then Unnamed Attachment Test
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="outer_boundary"
+
+--outer_boundary
+Content-Type: multipart/alternative; boundary="inner_boundary"
+Content-Disposition: attachment
+
+--inner_boundary
+Content-Type: text/plain
+
+This nested multipart part has no decodable payload.
+--inner_boundary--
+
+--outer_boundary
+Content-Type: application/octet-stream
+Content-Disposition: attachment
+
+This attachment has no filename.
+--outer_boundary--

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -338,3 +338,33 @@ class TestRegressionBug27:
 
         assert "payload.exe" in inv
         assert len(inv["payload.exe"]["Virustotal"]["SHA256"].split("/")[-1]) == 64
+
+
+class TestRegressionBug62:
+    """Regression tests for Bug #62 — unnamed attachment fallback index mismatch."""
+
+    def test_unnamed_attachment_fallback_name_matches_data_key(self):
+        """When earlier parts are skipped, the fallback name index must match the Data key."""
+        result = get_attachments(
+            fixture_path("skipped_then_unnamed_attachment.eml"), investigation=False
+        )
+        data = result["Attachments"]["Data"]
+        assert "1" in data
+        assert data["1"]["filename"] == "unnamed_attachment_1"
+
+    def test_unnamed_attachment_stored_at_key_one(self):
+        """The sole collected attachment must be at Data key '1'."""
+        result = get_attachments(
+            fixture_path("skipped_then_unnamed_attachment.eml"), investigation=False
+        )
+        assert len(result["Attachments"]["Data"]) == 1
+        assert "1" in result["Attachments"]["Data"]
+
+    def test_fallback_name_not_unnamed_attachment_two(self):
+        """Old bug: skipped part caused fallback name to be unnamed_attachment_2 at key '1'."""
+        result = get_attachments(
+            fixture_path("skipped_then_unnamed_attachment.eml"), investigation=False
+        )
+        data = result["Attachments"]["Data"]
+        assert data["1"]["filename"] != "unnamed_attachment_2"
+


### PR DESCRIPTION
The collection loop used enumerate() whose counter advanced even for skipped parts (payload is None), causing the fallback filename index to not match the Data dictionary key. Replaced with a manual counter that only increments when an attachment is successfully collected.