### PR TITLE
Extract URLs from plain-text body parts in get_links() (#68)

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -30,7 +30,8 @@ SUPPORTED_FILE_TYPES = ["eml"]
 SUPPORTED_OUTPUT_TYPES = ["json","html"]
 
 # REGEX
-LINK_REGEX = r'href=["\']([^"\'>\s]+)["\']'
+LINK_REGEX           = r'href=["\']([^"\'>\s]+)["\']'
+PLAINTEXT_URL_REGEX  = r'https?://\S+'
 MAIL_REGEX = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b'
 IP_REGEX   = r'\b(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b'
 AUTH_REGEX = r'\b(spf|dkim|dmarc)=(pass|fail|softfail|neutral|none|temperror|permerror)\b'
@@ -207,9 +208,10 @@ def _defang_url(url):
 def get_links(mail_data : str, investigation, defang=False):
     '''Get Links from mail data'''
 
-    # Parse the email and decode each text part individually
+    # Parse the email and extract links from each part by content type
     msg = message_from_string(mail_data, policy=policy.compat32)
-    decoded_parts = []
+    html_links   = []
+    plain_links  = []
     for part in msg.walk():
         if part.get_content_maintype() == "multipart":
             continue
@@ -218,16 +220,21 @@ def get_links(mail_data : str, investigation, defang=False):
             continue
         charset = part.get_content_charset() or "utf-8"
         try:
-            decoded_parts.append(payload.decode(charset, errors="replace"))
+            text = payload.decode(charset, errors="replace")
         except (LookupError, UnicodeDecodeError):
-            decoded_parts.append(payload.decode("utf-8", errors="replace"))
-    combined = "\n".join(decoded_parts)
+            text = payload.decode("utf-8", errors="replace")
 
-    # Find the Links
-    links = re.findall(LINK_REGEX, combined)
+        if part.get_content_type() == "text/html":
+            html_links.extend(re.findall(LINK_REGEX, text))
+        elif part.get_content_type() == "text/plain":
+            # Strip trailing punctuation that is unlikely to be part of a URL
+            plain_links.extend(
+                url.rstrip(".,;:!?)]>\"'")
+                for url in re.findall(PLAINTEXT_URL_REGEX, text)
+            )
 
-    # Remove Duplicates
-    links = list(dict.fromkeys(links))
+    # HTML href links take priority; plain-text URLs fill in anything new
+    links = list(dict.fromkeys(html_links + plain_links))
     # Remove Empty Values
     links = list(filter(None, links))
 

--- a/tests/fixtures/multipart_alt_links.eml
+++ b/tests/fixtures/multipart_alt_links.eml
@@ -1,0 +1,23 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Multipart Alternative Links Test
+Date: Wed, 02 Apr 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="alt_boundary"
+
+--alt_boundary
+Content-Type: text/plain; charset="utf-8"
+
+Click here: https://phishing-site.com/verify
+Also see: https://plaintext-only.com/exclusive
+
+--alt_boundary
+Content-Type: text/html; charset="utf-8"
+
+<!DOCTYPE html>
+<html><body>
+<a href="https://phishing-site.com/verify">Click here</a>
+<a href="https://html-only.com/page">HTML only link</a>
+</body></html>
+
+--alt_boundary--

--- a/tests/fixtures/plaintext_links.eml
+++ b/tests/fixtures/plaintext_links.eml
@@ -1,0 +1,11 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Plain Text Links Test
+Date: Wed, 02 Apr 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Please verify your account at https://phishing-site.com/verify
+Or visit http://backup-site.net/confirm for more info.
+Do not reply to this email.
+For questions see https://help.example.com/faq.

--- a/tests/test_plaintext_links.py
+++ b/tests/test_plaintext_links.py
@@ -1,0 +1,105 @@
+"""
+Tests for plain-text body URL extraction (Enhancement #68)
+
+Covers:
+- Bare URLs in plain-text-only emails are extracted
+- http:// and https:// both matched in plain text
+- Multiple plain-text URLs extracted and indexed
+- Trailing punctuation stripped from plain-text URLs
+- multipart/alternative: HTML href links + plain-text-only URLs both extracted
+- Shared URL across HTML and plain text deduplicated (appears once)
+- HTML-only link still extracted when plain text has no unique URLs
+- Plain-text-only URL appears after HTML links in output order
+- Investigation mode works on plain-text extracted URLs
+- Defang flag applies to plain-text extracted URLs
+"""
+
+import pytest
+from conftest import get_links, load_fixture
+
+
+class TestPlaintextLinkExtraction:
+    def test_bare_https_url_extracted_from_plaintext(self):
+        result = get_links(load_fixture("plaintext_links.eml"), investigation=False)
+        values = list(result["Links"]["Data"].values())
+        assert any("phishing-site.com" in v for v in values)
+
+    def test_bare_http_url_extracted_from_plaintext(self):
+        result = get_links(load_fixture("plaintext_links.eml"), investigation=False)
+        values = list(result["Links"]["Data"].values())
+        assert any("http://backup-site.net" in v for v in values)
+
+    def test_multiple_plaintext_urls_all_extracted(self):
+        result = get_links(load_fixture("plaintext_links.eml"), investigation=False)
+        assert len(result["Links"]["Data"]) == 3
+
+    def test_plaintext_urls_indexed_from_one(self):
+        result = get_links(load_fixture("plaintext_links.eml"), investigation=False)
+        keys = list(result["Links"]["Data"].keys())
+        assert keys[0] == "1"
+
+    def test_plaintext_url_trailing_period_stripped(self):
+        """URLs followed by a period (end of sentence) must not include the period."""
+        result = get_links(load_fixture("plaintext_links.eml"), investigation=False)
+        values = list(result["Links"]["Data"].values())
+        assert not any(v.endswith(".") for v in values)
+
+    def test_no_links_plaintext_returns_empty(self):
+        result = get_links(load_fixture("no_links.eml"), investigation=False)
+        assert result["Links"]["Data"] == {}
+
+
+class TestMultipartAltLinkExtraction:
+    def test_html_href_links_extracted(self):
+        result = get_links(load_fixture("multipart_alt_links.eml"), investigation=False)
+        values = list(result["Links"]["Data"].values())
+        assert any("html-only.com" in v for v in values)
+
+    def test_plaintext_only_url_extracted(self):
+        """URL present only in plain-text part must be extracted."""
+        result = get_links(load_fixture("multipart_alt_links.eml"), investigation=False)
+        values = list(result["Links"]["Data"].values())
+        assert any("plaintext-only.com" in v for v in values)
+
+    def test_shared_url_deduplicated(self):
+        """URL appearing in both HTML and plain text must appear only once."""
+        result = get_links(load_fixture("multipart_alt_links.eml"), investigation=False)
+        values = list(result["Links"]["Data"].values())
+        phishing_count = sum(1 for v in values if "phishing-site.com" in v)
+        assert phishing_count == 1
+
+    def test_total_unique_links_count(self):
+        """Three unique URLs across both parts must produce three entries."""
+        result = get_links(load_fixture("multipart_alt_links.eml"), investigation=False)
+        assert len(result["Links"]["Data"]) == 3
+
+    def test_html_links_appear_before_plaintext_only_links(self):
+        """HTML href links take priority and appear first in the output."""
+        result = get_links(load_fixture("multipart_alt_links.eml"), investigation=False)
+        data = result["Links"]["Data"]
+        # phishing-site.com is in both — must be at index 1 (from HTML)
+        assert "phishing-site.com" in data["1"]
+        # plaintext-only.com is only in plain text — must appear last
+        assert "plaintext-only.com" in data["3"]
+
+
+class TestPlaintextInvestigation:
+    def test_investigation_works_on_plaintext_urls(self):
+        result = get_links(load_fixture("plaintext_links.eml"), investigation=True)
+        inv = result["Links"]["Investigation"]
+        assert len(inv) == 3
+        for entry in inv.values():
+            assert "Virustotal" in entry
+            assert "Urlscan" in entry
+
+    def test_investigation_count_matches_data_count(self):
+        result = get_links(load_fixture("multipart_alt_links.eml"), investigation=True)
+        assert len(result["Links"]["Data"]) == len(result["Links"]["Investigation"])
+
+
+class TestPlaintextDefang:
+    def test_defang_applies_to_plaintext_urls(self):
+        result = get_links(load_fixture("plaintext_links.eml"), investigation=False, defang=True)
+        values = list(result["Links"]["Data"].values())
+        assert all(v.startswith("hxxp") for v in values)
+        assert all("[.]" in v for v in values)


### PR DESCRIPTION
Previously only href attributes in HTML parts were extracted. Now text/plain parts are also scanned using a bare URL regex, with trailing punctuation stripped. HTML href links take priority in ordering; plain-text-only URLs fill in after. Results are deduplicated across both sources. Defang and investigation modes apply to all extracted URLs regardless of source.