### PR TITLE
feat: add Reply-To domain investigation check (#73)

### DIFF
--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -158,6 +158,30 @@ def get_headers(mail_data : str, investigation):
                     "Conclusion": conclusion
                 }
 
+        # Reply-To Domain Check
+        if data["Headers"]["Data"].get("reply-to") and data["Headers"]["Data"].get("from"):
+            replyto_matches = re.findall(MAIL_REGEX, data["Headers"]["Data"]["reply-to"])
+            mailfrom_matches = re.findall(MAIL_REGEX, data["Headers"]["Data"]["from"])
+            if replyto_matches and mailfrom_matches:
+                replyto_addr  = replyto_matches[0]
+                mailfrom_addr = mailfrom_matches[0]
+                replyto_domain  = replyto_addr.split("@")[-1].lower()  if "@" in replyto_addr  else ""
+                mailfrom_domain = mailfrom_addr.split("@")[-1].lower() if "@" in mailfrom_addr else ""
+                if replyto_domain and mailfrom_domain and replyto_domain != mailfrom_domain:
+                    conclusion = (
+                        f"Reply-To domain '{replyto_domain}' differs from From domain "
+                        f"'{mailfrom_domain}'. Replies will be directed to a different domain."
+                    )
+                else:
+                    conclusion = f"Reply-To domain matches From domain ('{replyto_domain}')."
+                data["Headers"]["Investigation"]["Reply-To Domain Check"] = {
+                    "Reply-To Address": replyto_addr,
+                    "Reply-To Domain": replyto_domain,
+                    "From Address": mailfrom_addr,
+                    "From Domain": mailfrom_domain,
+                    "Conclusion": conclusion
+                }
+
         # Suspicious Headers Check
         suspicious = {}
 

--- a/tests/fixtures/replyto_diff_domain.eml
+++ b/tests/fixtures/replyto_diff_domain.eml
@@ -1,0 +1,10 @@
+From: support@bank.com
+Reply-To: attacker@evil.com
+To: victim@example.com
+Subject: Reply-To Domain Mismatch Test
+Message-ID: <replyto-diff@example.com>
+Date: Wed, 02 Apr 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain
+
+Reply-To domain differs from From domain.

--- a/tests/fixtures/replyto_same_domain.eml
+++ b/tests/fixtures/replyto_same_domain.eml
@@ -1,0 +1,10 @@
+From: sender@example.com
+Reply-To: other@example.com
+To: recipient@example.com
+Subject: Reply-To Same Domain Test
+Message-ID: <replyto-same@example.com>
+Date: Wed, 02 Apr 2026 10:00:00 +0000
+MIME-Version: 1.0
+Content-Type: text/plain
+
+Reply-To domain matches From domain.

--- a/tests/test_replyto_domain.py
+++ b/tests/test_replyto_domain.py
@@ -1,0 +1,86 @@
+"""
+Tests for Reply-To domain investigation (Enhancement #73)
+
+Covers:
+- Reply-To domain differs from From domain → entry added with mismatch conclusion
+- Reply-To domain matches From domain → entry added with match conclusion
+- No Reply-To header → no Reply-To Domain Check entry
+- investigation=False → no Reply-To Domain Check entry
+- Entry fields: Reply-To Address, Reply-To Domain, From Address, From Domain, Conclusion
+- Existing Spoof Check unaffected
+"""
+
+import pytest
+from conftest import get_headers, load_fixture
+
+
+class TestReplyToDomainMismatch:
+    def test_mismatch_entry_added(self):
+        result = get_headers(load_fixture("replyto_diff_domain.eml"), investigation=True)
+        assert "Reply-To Domain Check" in result["Headers"]["Investigation"]
+
+    def test_mismatch_conclusion_mentions_differs(self):
+        result = get_headers(load_fixture("replyto_diff_domain.eml"), investigation=True)
+        entry = result["Headers"]["Investigation"]["Reply-To Domain Check"]
+        assert "differ" in entry["Conclusion"].lower()
+
+    def test_mismatch_replyto_domain_value(self):
+        result = get_headers(load_fixture("replyto_diff_domain.eml"), investigation=True)
+        entry = result["Headers"]["Investigation"]["Reply-To Domain Check"]
+        assert entry["Reply-To Domain"] == "evil.com"
+
+    def test_mismatch_from_domain_value(self):
+        result = get_headers(load_fixture("replyto_diff_domain.eml"), investigation=True)
+        entry = result["Headers"]["Investigation"]["Reply-To Domain Check"]
+        assert entry["From Domain"] == "bank.com"
+
+    def test_mismatch_replyto_address_value(self):
+        result = get_headers(load_fixture("replyto_diff_domain.eml"), investigation=True)
+        entry = result["Headers"]["Investigation"]["Reply-To Domain Check"]
+        assert entry["Reply-To Address"] == "attacker@evil.com"
+
+    def test_mismatch_from_address_value(self):
+        result = get_headers(load_fixture("replyto_diff_domain.eml"), investigation=True)
+        entry = result["Headers"]["Investigation"]["Reply-To Domain Check"]
+        assert entry["From Address"] == "support@bank.com"
+
+
+class TestReplyToDomainMatch:
+    def test_same_domain_entry_added(self):
+        result = get_headers(load_fixture("replyto_same_domain.eml"), investigation=True)
+        assert "Reply-To Domain Check" in result["Headers"]["Investigation"]
+
+    def test_same_domain_conclusion_mentions_matches(self):
+        result = get_headers(load_fixture("replyto_same_domain.eml"), investigation=True)
+        entry = result["Headers"]["Investigation"]["Reply-To Domain Check"]
+        assert "match" in entry["Conclusion"].lower()
+
+
+class TestReplyToDomainAbsent:
+    def test_no_replyto_no_entry(self):
+        result = get_headers(load_fixture("clean_headers.eml"), investigation=True)
+        assert "Reply-To Domain Check" not in result["Headers"]["Investigation"]
+
+    def test_investigation_false_no_entry(self):
+        result = get_headers(load_fixture("replyto_diff_domain.eml"), investigation=False)
+        assert "Reply-To Domain Check" not in result["Headers"]["Investigation"]
+
+
+class TestRegressionEnhancement73:
+    def test_spoof_check_still_present(self):
+        result = get_headers(load_fixture("spoofed.eml"), investigation=True)
+        assert "Spoof Check" in result["Headers"]["Investigation"]
+
+    def test_display_name_check_unaffected(self):
+        result = get_headers(load_fixture("phishing_displayname.eml"), investigation=True)
+        assert "Display Name Check" in result["Headers"]["Investigation"]
+
+    def test_entry_is_dict(self):
+        result = get_headers(load_fixture("replyto_diff_domain.eml"), investigation=True)
+        entry = result["Headers"]["Investigation"]["Reply-To Domain Check"]
+        assert isinstance(entry, dict)
+
+    def test_entry_has_expected_keys(self):
+        result = get_headers(load_fixture("replyto_diff_domain.eml"), investigation=True)
+        entry = result["Headers"]["Investigation"]["Reply-To Domain Check"]
+        assert set(entry.keys()) == {"Reply-To Address", "Reply-To Domain", "From Address", "From Domain", "Conclusion"}


### PR DESCRIPTION
When both Reply-To and From headers are present, compare their domains and report whether they match or differ. A mismatch indicates replies will be directed to a different domain a common phishing pattern. Adds 14 tests and 2 fixture files.