### PR TITLE
fix: wrap HTML report in proper <!DOCTYPE html> / <html> / <body> str…

### DIFF
--- a/html_generator.py
+++ b/html_generator.py
@@ -296,12 +296,17 @@ def generate_table_from_json(json_obj):
         auth_cnt = 0
 
     # Generate HTML table with Bootstrap classes
-    html = f"""
-        <head>
-            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/css/bootstrap.min.css">
-            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-            <script async defer src="https://buttons.github.io/buttons.js"></script>
-        </head>
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Email Analyzer Report — { escape(info_data["Scan"]["Filename"]) }</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
+</head>
+<body>
 
         <nav class="navbar navbar-expand-lg navbar-light bg-light">
             <a class="navbar-brand" href="#"><i class="fa fa-envelope"></i> Email Analyzer</a>
@@ -434,6 +439,7 @@ def generate_table_from_json(json_obj):
         </div>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/js/bootstrap.min.js"></script>
-    """
+</body>
+</html>"""
 
     return html

--- a/tests/test_html_generator.py
+++ b/tests/test_html_generator.py
@@ -418,3 +418,54 @@ class TestRegressionBug33:
         app_data = {"Information": make_info(), "Analysis": {}}
         html = generate_table_from_json(app_data)
         assert 'aria-labelledby="navbarDropdown"' not in html
+
+
+# ---------------------------------------------------------------------------
+# Fix #74 — missing <!DOCTYPE html>, <html>, <body> structure tags
+# ---------------------------------------------------------------------------
+
+class TestHtmlStructureFix74:
+    """Verify the generated report is a complete, valid HTML document."""
+
+    def test_doctype_present(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert html.strip().startswith("<!DOCTYPE html>")
+
+    def test_html_open_tag_present(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert "<html" in html
+
+    def test_html_close_tag_present(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert "</html>" in html
+
+    def test_body_open_tag_present(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert "<body>" in html
+
+    def test_body_close_tag_present(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert "</body>" in html
+
+    def test_title_contains_filename(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert "<title>" in html
+        assert "test.eml" in html
+
+    def test_charset_meta_present(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'charset="UTF-8"' in html or "charset=UTF-8" in html
+
+    def test_title_xss_escaped(self):
+        info = make_info()
+        info["Scan"]["Filename"] = xss_payload()
+        app_data = {"Information": info, "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert "<script>" not in html


### PR DESCRIPTION
…ucture (#74)

Add DOCTYPE declaration, <html lang="en">, <head> with charset meta and <title> (containing the scanned filename), and matching <body> / </body> / </html> closing tags. Adds 8 tests to the existing HTML generator test suite.