### PR TITLE
feat: add --version flag and VERSION constant (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ With EmailAnalyzer you can able to analyze your suspicious emails. You can extra
 
 ## Usage
 ```
-usage: email-analyzer.py [-h] -f FILENAME [-H] [-d] [-l] [-a] [-A] [-D] [-i] [-o OUTPUT]
+usage: email-analyzer.py [-h] [--version] -f FILENAME [-H] [-d] [-l] [-a] [-A] [-D] [-i] [-o OUTPUT]
 
 options:
   -h, --help            show this help message and exit
+  --version             Show program version and exit
   -f, --filename FILENAME
                         Name of the EML file
   -H, --headers         To get the Headers of the Email
@@ -414,6 +415,11 @@ _________________________________________________________
 ```
 
 > When two or more attachments share the same SHA256 hash, a **Duplicate Warning** is added to the investigation output listing the shared hash and the filenames involved.
+
+## To Check Version
+```
+python3 email-analyzer.py --version
+```
 
 ## Testing
 

--- a/email-analyzer.py
+++ b/email-analyzer.py
@@ -24,6 +24,9 @@ from html_generator import generate_table_from_json
 
 # Global Values
 ##############################################################################
+# Version
+VERSION = "2.0"
+
 # Supported File Types
 SUPPORTED_FILE_TYPES = ["eml"]
 
@@ -550,6 +553,11 @@ def write_to_file(filename, data):
 if __name__ == '__main__':
     parser = ArgumentParser()
     parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {VERSION}"
+    )
+    parser.add_argument(
         "-f",
         "--filename",
         type=str,
@@ -644,7 +652,7 @@ if __name__ == '__main__':
     app_data["Information"]["Project"] = {
         "Name":"EmailAnalyzer",
         "Url":"https://github.com/keraattin/EmailAnalyzer",
-        "Version": "2.0",
+        "Version": VERSION,
     }
     app_data["Information"]["Scan"] = {
         "Filename": filename,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ Covers:
 - Unsupported input file format exits with error
 - Unsupported output format exits with error before analysis
 - Valid file runs without error
+- --version flag prints version and exits with code 0 (#75)
 """
 
 import subprocess
@@ -59,3 +60,26 @@ class TestRegressionBug61:
         assert returncode != 0
         # No analysis banner should appear — exited before any work
         assert "EmailAnalyzer" not in stdout
+
+
+class TestVersionFlag:
+    """Tests for the --version flag (Enhancement #75)."""
+
+    def test_version_exits_zero(self):
+        returncode, _, _ = run_cli("--version")
+        assert returncode == 0
+
+    def test_version_prints_version_number(self):
+        _, stdout, stderr = run_cli("--version")
+        combined = stdout + stderr
+        assert "2.0" in combined
+
+    def test_version_works_without_filename(self):
+        """--version must not require -f to be present."""
+        returncode, _, _ = run_cli("--version")
+        assert returncode == 0
+
+    def test_version_output_contains_script_name(self):
+        _, stdout, stderr = run_cli("--version")
+        combined = stdout + stderr
+        assert "email-analyzer" in combined


### PR DESCRIPTION
Add a VERSION constant (currently "2.0") used by both the --version CLI flag and the JSON/HTML report output, replacing the previously hardcoded string. Update README usage block and add a To Check Version section. Adds 4 CLI tests.