### PR TITLE
feat: add threat summary section to HTML report (#76)

### DIFF
--- a/html_generator.py
+++ b/html_generator.py
@@ -256,6 +256,90 @@ def generate_digest_section(digests):
     return html
     ######################################################################
 
+def generate_summary_section(data):
+    headers_data = data.get("Headers", {}).get("Data", {})
+    headers_inv  = data.get("Headers", {}).get("Investigation", {})
+    auth_data    = data.get("Authentication", {}).get("Data", {})
+    links_cnt    = len(data.get("Links", {}).get("Data", {}))
+    attach_cnt   = len(data.get("Attachments", {}).get("Data", {}))
+
+    # Collect triggered threat flags
+    threat_flags = []
+
+    spoof = headers_inv.get("Spoof Check", {})
+    if "SPOOFED" in spoof.get("Conclusion", ""):
+        threat_flags.append(("danger", "Spoof Check", spoof["Conclusion"]))
+
+    dn = headers_inv.get("Display Name Check", {})
+    if "impersonation" in dn.get("Conclusion", "").lower():
+        threat_flags.append(("warning", "Display Name Check", dn["Conclusion"]))
+
+    rt = headers_inv.get("Reply-To Domain Check", {})
+    if "differ" in rt.get("Conclusion", "").lower():
+        threat_flags.append(("warning", "Reply-To Domain Check", rt["Conclusion"]))
+
+    for flag_name, flag_detail in headers_inv.get("Suspicious Headers", {}).items():
+        threat_flags.append(("warning", f"Suspicious Header: {flag_name}", flag_detail))
+
+    for proto, result in auth_data.items():
+        if result in ("fail", "softfail"):
+            threat_flags.append(("danger", f"Auth Failure: {proto.upper()}", f"{proto.upper()} result is '{result}'"))
+
+    dup = headers_inv.get("Duplicate Warning") or data.get("Attachments", {}).get("Investigation", {}).get("Duplicate Warning")
+    if dup:
+        threat_flags.append(("warning", "Duplicate Attachments", "One or more attachments share the same SHA256 hash."))
+
+    # Threat level
+    if any(color == "danger" for color, _, _ in threat_flags):
+        level, level_class = "HIGH", "danger"
+    elif threat_flags:
+        level, level_class = "MEDIUM", "warning"
+    else:
+        level, level_class = "LOW", "success"
+
+    html = """
+        <h2 id="summary-section" style="text-align: center;"><i class="fa-solid fa-shield-halved"></i> Threat Summary</h2>
+        <hr>
+        <div class="row">
+            <div class="col-md-6">
+                <h3><i class="fa-solid fa-envelope-open-text"></i> Email Overview</h3>
+                <table class="table table-bordered table-striped">
+                    <tbody>
+    """
+    for field in ("from", "to", "subject", "date"):
+        value = headers_data.get(field, "—")
+        html += f"<tr><td><b>{escape(field.capitalize())}</b></td><td>{escape(str(value))}</td></tr>"
+    html += f"""
+                        <tr><td><b>Links Found</b></td><td>{links_cnt}</td></tr>
+                        <tr><td><b>Attachments Found</b></td><td>{attach_cnt}</td></tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="col-md-6">
+                <h3><i class="fa-solid fa-triangle-exclamation"></i> Threat Level &nbsp;
+                    <span class="badge badge-{level_class}">{escape(level)}</span>
+                </h3>
+                <hr>
+    """
+
+    if threat_flags:
+        for color, name, detail in threat_flags:
+            html += f"""
+                <div class="alert alert-{color}" role="alert">
+                    <b>{escape(name)}</b><br>{escape(str(detail))}
+                </div>
+            """
+    else:
+        html += '<div class="alert alert-success" role="alert">No threat indicators detected.</div>'
+
+    html += """
+            </div>
+        </div>
+        <hr>
+    """
+    return html
+
+
 def generate_table_from_json(json_obj):
     # Parse JSON object
     data = json_obj["Analysis"]
@@ -316,6 +400,9 @@ def generate_table_from_json(json_obj):
 
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav mr-auto">
+                <li class="nav-item">
+                    <a class="nav-link" href="#summary-section"><i class="fa-solid fa-shield-halved"></i> Summary</a>
+                </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle" href="#" id="headersDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Headers
@@ -418,6 +505,8 @@ def generate_table_from_json(json_obj):
             </div>
         </div>
     """
+
+    html += generate_summary_section(data)
 
     if data.get("Headers"):
         html += generate_headers_section(data["Headers"])

--- a/tests/test_html_generator.py
+++ b/tests/test_html_generator.py
@@ -33,6 +33,7 @@ generate_headers_section    = mod.generate_headers_section
 generate_links_section      = mod.generate_links_section
 generate_attachment_section = mod.generate_attachment_section
 generate_digest_section     = mod.generate_digest_section
+generate_summary_section    = mod.generate_summary_section
 generate_table_from_json    = mod.generate_table_from_json
 
 
@@ -468,4 +469,120 @@ class TestHtmlStructureFix74:
         info["Scan"]["Filename"] = xss_payload()
         app_data = {"Information": info, "Analysis": {}}
         html = generate_table_from_json(app_data)
+        assert "<script>" not in html
+
+
+# ---------------------------------------------------------------------------
+# Enhancement #76 — Threat Summary section
+# ---------------------------------------------------------------------------
+
+def make_clean_analysis():
+    return {
+        "Headers": {
+            "Data": {"from": "sender@example.com", "to": "recipient@example.com",
+                     "subject": "Hello", "date": "Wed, 02 Apr 2026 10:00:00 +0000"},
+            "Investigation": {}
+        }
+    }
+
+
+class TestSummarySectionStructure:
+    def test_summary_section_present_in_full_report(self):
+        app_data = {"Information": make_info(), "Analysis": make_clean_analysis()}
+        html = generate_table_from_json(app_data)
+        assert "summary-section" in html
+
+    def test_summary_nav_link_present(self):
+        app_data = {"Information": make_info(), "Analysis": make_clean_analysis()}
+        html = generate_table_from_json(app_data)
+        assert "#summary-section" in html
+
+    def test_threat_level_shown(self):
+        data = make_clean_analysis()
+        html = generate_summary_section(data)
+        assert "Threat Level" in html
+
+    def test_email_overview_shows_from(self):
+        data = make_clean_analysis()
+        html = generate_summary_section(data)
+        assert "sender@example.com" in html
+
+    def test_email_overview_shows_subject(self):
+        data = make_clean_analysis()
+        html = generate_summary_section(data)
+        assert "Hello" in html
+
+    def test_links_count_shown(self):
+        data = make_clean_analysis()
+        data["Links"] = {"Data": {"1": "https://a.com", "2": "https://b.com"}, "Investigation": {}}
+        html = generate_summary_section(data)
+        assert "2" in html
+
+    def test_attachments_count_shown(self):
+        data = make_clean_analysis()
+        data["Attachments"] = {"Data": {"1": {"filename": "f.pdf", "mime_type": "application/pdf"}}, "Investigation": {}}
+        html = generate_summary_section(data)
+        assert "1" in html
+
+
+class TestSummaryThreatLevel:
+    def test_low_threat_when_clean(self):
+        data = make_clean_analysis()
+        html = generate_summary_section(data)
+        assert "LOW" in html
+
+    def test_high_threat_on_spoof(self):
+        data = make_clean_analysis()
+        data["Headers"]["Investigation"]["Spoof Check"] = {
+            "Reply-To": "x@evil.com", "From": "y@bank.com",
+            "Conclusion": "Reply Address and From Address is NOT Same. This mail may be SPOOFED."
+        }
+        html = generate_summary_section(data)
+        assert "HIGH" in html
+
+    def test_medium_threat_on_display_name_mismatch(self):
+        data = make_clean_analysis()
+        data["Headers"]["Investigation"]["Display Name Check"] = {
+            "Display Name": "paypal.com", "Address": "attacker@gmail.com",
+            "Sending Domain": "gmail.com",
+            "Conclusion": "Display name contains 'paypal.com' which does not match sending domain 'gmail.com'. Possible impersonation."
+        }
+        html = generate_summary_section(data)
+        assert "MEDIUM" in html
+
+    def test_medium_threat_on_replyto_mismatch(self):
+        data = make_clean_analysis()
+        data["Headers"]["Investigation"]["Reply-To Domain Check"] = {
+            "Reply-To Address": "a@evil.com", "Reply-To Domain": "evil.com",
+            "From Address": "b@bank.com", "From Domain": "bank.com",
+            "Conclusion": "Reply-To domain 'evil.com' differs from From domain 'bank.com'."
+        }
+        html = generate_summary_section(data)
+        assert "MEDIUM" in html
+
+    def test_high_threat_on_auth_failure(self):
+        data = make_clean_analysis()
+        data["Authentication"] = {"Data": {"spf": "fail"}}
+        html = generate_summary_section(data)
+        assert "HIGH" in html
+
+    def test_suspicious_header_flag_shown(self):
+        data = make_clean_analysis()
+        data["Headers"]["Investigation"]["Suspicious Headers"] = {
+            "Missing Message-ID": "Legitimate MTAs always generate a Message-ID."
+        }
+        html = generate_summary_section(data)
+        assert "Missing Message-ID" in html
+
+    def test_no_threat_indicators_message_when_clean(self):
+        data = make_clean_analysis()
+        html = generate_summary_section(data)
+        assert "No threat indicators detected" in html
+
+    def test_xss_in_threat_flag_detail_escaped(self):
+        data = make_clean_analysis()
+        data["Headers"]["Investigation"]["Suspicious Headers"] = {
+            "Test": xss_payload()
+        }
+        html = generate_summary_section(data)
         assert "<script>" not in html


### PR DESCRIPTION
Add a Threat Summary section (with navbar link) that shows key email fields, counts of links and attachments, a threat level badge (LOW / MEDIUM / HIGH), and Bootstrap alert cards for each triggered investigation check (spoof, display name mismatch, Reply-To domain mismatch, suspicious headers, auth failures, duplicate attachments). All values are HTML-escaped. Adds 15 tests.