### PR TITLE
feat: add sticky navbar and copy-to-clipboard buttons to HTML report …

### DIFF
--- a/html_generator.py
+++ b/html_generator.py
@@ -70,8 +70,10 @@ def generate_links_section(links):
     """
     for key,value in links["Data"].items():
         # Populate table rows
+        js_val = escape(json.dumps(str(value)))
+        copy_btn = f'<button class="btn btn-sm btn-outline-secondary ml-2" onclick="copyToClipboard({js_val})" title="Copy"><i class="fa-regular fa-copy"></i></button>'
         html += "<tr>"
-        html += "<td>{}</td><td>{}</td>".format(escape(str(key)), escape(str(value)))
+        html += "<td>{}</td><td>{}{}</td>".format(escape(str(key)), escape(str(value)), copy_btn)
         html += "</tr>"
         
     html += """
@@ -218,8 +220,10 @@ def generate_digest_section(digests):
     """
     for key,value in digests["Data"].items():
         # Populate table rows
+        js_val = escape(json.dumps(str(value)))
+        copy_btn = f'<button class="btn btn-sm btn-outline-secondary ml-2" onclick="copyToClipboard({js_val})" title="Copy"><i class="fa-regular fa-copy"></i></button>'
         html += "<tr>"
-        html += "<td>{}</td><td>{}</td>".format(escape(str(key)), escape(str(value)))
+        html += "<td>{}</td><td>{}{}</td>".format(escape(str(key)), escape(str(value)), copy_btn)
         html += "</tr>"
         
     html += """
@@ -389,10 +393,24 @@ def generate_table_from_json(json_obj):
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.6.0/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <script>
+    function copyToClipboard(text) {{
+        if (navigator.clipboard) {{
+            navigator.clipboard.writeText(text);
+        }} else {{
+            var el = document.createElement('textarea');
+            el.value = text;
+            document.body.appendChild(el);
+            el.select();
+            document.execCommand('copy');
+            document.body.removeChild(el);
+        }}
+    }}
+    </script>
 </head>
 <body>
 
-        <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light sticky-top">
             <a class="navbar-brand" href="#"><i class="fa fa-envelope"></i> Email Analyzer</a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>

--- a/tests/test_html_generator.py
+++ b/tests/test_html_generator.py
@@ -278,14 +278,14 @@ class TestInformationSectionEscaping:
         info["Scan"]["Filename"] = xss_payload()
         app_data = {"Information": info, "Analysis": {}}
         html = generate_table_from_json(app_data)
-        assert "<script>" not in html
+        assert xss_payload() not in html
 
     def test_scan_generated_escaped(self):
         info = make_info()
         info["Scan"]["Generated"] = xss_payload()
         app_data = {"Information": info, "Analysis": {}}
         html = generate_table_from_json(app_data)
-        assert "<script>" not in html
+        assert xss_payload() not in html
 
     def test_safe_scan_filename_rendered_correctly(self):
         info = make_info()
@@ -469,7 +469,7 @@ class TestHtmlStructureFix74:
         info["Scan"]["Filename"] = xss_payload()
         app_data = {"Information": info, "Analysis": {}}
         html = generate_table_from_json(app_data)
-        assert "<script>" not in html
+        assert xss_payload() not in html
 
 
 # ---------------------------------------------------------------------------
@@ -586,3 +586,59 @@ class TestSummaryThreatLevel:
         }
         html = generate_summary_section(data)
         assert "<script>" not in html
+
+
+# ---------------------------------------------------------------------------
+# Enhancement #77 — sticky navbar + copy-to-clipboard buttons
+# ---------------------------------------------------------------------------
+
+class TestStickyNavbar:
+    def test_navbar_has_sticky_top_class(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert "sticky-top" in html
+
+    def test_navbar_class_contains_navbar(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert 'class="navbar' in html
+
+
+class TestCopyToClipboard:
+    def test_js_function_defined_in_report(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert "copyToClipboard" in html
+
+    def test_copy_button_present_in_digest_data(self):
+        data = {
+            "Data": {"File MD5": "d41d8cd98f00b204e9800998ecf8427e"},
+            "Investigation": {}
+        }
+        html = generate_digest_section(data)
+        assert "copyToClipboard" in html
+        assert "d41d8cd98f00b204e9800998ecf8427e" in html
+
+    def test_copy_button_present_in_links_data(self):
+        data = {"Data": {"1": "https://example.com"}, "Investigation": {}}
+        html = generate_links_section(data)
+        assert "copyToClipboard" in html
+        assert "https://example.com" in html
+
+    def test_copy_button_value_xss_escaped(self):
+        data = {
+            "Data": {"File MD5": xss_payload()},
+            "Investigation": {}
+        }
+        html = generate_digest_section(data)
+        assert "<script>" not in html
+
+    def test_copy_button_url_xss_escaped(self):
+        data = {"Data": {"1": xss_payload()}, "Investigation": {}}
+        html = generate_links_section(data)
+        assert "<script>" not in html
+
+    def test_clipboard_api_used_in_js(self):
+        app_data = {"Information": make_info(), "Analysis": {}}
+        html = generate_table_from_json(app_data)
+        assert "navigator.clipboard" in html


### PR DESCRIPTION
…(#77)

Make the navbar sticky (sticky-top) so it stays visible while scrolling. Add a copyToClipboard() JS helper (with navigator.clipboard + execCommand fallback) and copy buttons next to hash values in the Digests section and URLs in the Links section. Update three XSS tests to assert on the full payload string rather than any <script> tag. Adds 8 tests.